### PR TITLE
do not output "Silencer using global filters" warning if there are no global filters

### DIFF
--- a/silencer-plugin/src/main/scala/com/github/ghik/silencer/SilencerPlugin.scala
+++ b/silencer-plugin/src/main/scala/com/github/ghik/silencer/SilencerPlugin.scala
@@ -22,7 +22,9 @@ class SilencerPlugin(val global: Global) extends Plugin { plugin =>
       }
     }
 
-    global.inform(s"""Silencer using global filters: ${globalFilters.mkString(",")}""")
+    if (globalFilters.nonEmpty) {
+      global.inform(s"""Silencer using global filters: ${globalFilters.mkString(",")}""")
+    }
 
     global.reporter = reporter
   }


### PR DESCRIPTION
Currently on each compilation run the following message appears:

```
[info] Silencer using global filters: 
```

That is slightly scary. Can we please remove this if there are no actual global filters in action?