### PR TITLE
Cross-build for 2.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ val commonSettings = Def.settings(
   organization := "com.github.ghik",
   scalaVersion := crossScalaVersions.value.head,
   crossVersion := CrossVersion.full,
-  crossScalaVersions := Seq("2.13.2", "2.12.11", "2.11.12"),
+  crossScalaVersions := Seq("2.13.2", "2.13.1", "2.12.11", "2.11.12"),
   inConfig(Compile)(crossSources),
   inConfig(Test)(crossSources),
   projectInfo := ModuleInfo(


### PR DESCRIPTION
`2.13.2` introduced a regression that makes it impossible to build some projects with it, with no viable workaround yet (https://github.com/scala/bug/issues/11968)
Could you please publish version 1.7 for `2.13.1` too? In this case I could use silencer with `@nowarn` in those projects that are affected and can't be updated yet, thanks!