### PR TITLE
Delay `@silent` annotation checking & warning

### DIFF
--- a/silencer-plugin/src/main/scala/com/github/ghik/silencer/SilencerPlugin.scala
+++ b/silencer-plugin/src/main/scala/com/github/ghik/silencer/SilencerPlugin.scala
@@ -84,17 +84,18 @@ class SilencerPlugin(val global: Global) extends Plugin with SilencerPluginCompa
         case _: ScalaReflectionException => NoSymbol
       }
 
-    def newPhase(prev: Phase): StdPhase = {
+    private lazy val checkAnnotation: Unit = {
       if (silentSym == NoSymbol && compatNowarnSym == NoSymbol && globalFilters.isEmpty && pathFilters.isEmpty) {
         plugin.reporter.warning(NoPosition,
           "`silencer-plugin` was enabled but @silent annotation was not found on classpath" +
             " - have you added `silencer-lib` as a library dependency?"
         )
       }
+    }
 
-      new StdPhase(prev) {
-        def apply(unit: CompilationUnit): Unit = applySuppressions(unit)
-      }
+    def newPhase(prev: Phase): StdPhase = new StdPhase(prev) {
+      override def run(): Unit = { checkAnnotation: Unit; super.run() }
+      def apply(unit: CompilationUnit): Unit = applySuppressions(unit)
     }
 
     def applySuppressions(unit: CompilationUnit): Unit = {


### PR DESCRIPTION
In Scala 2.13.7 we've tweaked how package objects are loaded, which
leads to an initialisation order problem.  Here's the stack:

    java.lang.NullPointerException:
    at scala.tools.nsc.Global.isPast(Global.scala:1028)
    at scala.tools.nsc.Global.openPackageModule(Global.scala:85)
    at scala.tools.nsc.symtab.SymbolLoaders$PackageLoader.doComplete(SymbolLoaders.scala:312)
    at scala.tools.nsc.symtab.SymbolLoaders$SymbolLoader.$anonfun$complete$2(SymbolLoaders.scala:249)
    at scala.tools.nsc.symtab.SymbolLoaders$SymbolLoader.complete(SymbolLoaders.scala:247)
    at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1561)
    at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1533)
    at scala.reflect.internal.Types$TypeRef.baseClasses(Types.scala:2617)
    at scala.reflect.internal.tpe.FindMembers$FindMemberBase.init(FindMembers.scala:37)
    at scala.reflect.internal.tpe.FindMembers$FindMember.init(FindMembers.scala:258)
    at scala.reflect.internal.Types$Type.$anonfun$findMember$1(Types.scala:1043)
    at scala.reflect.internal.Types$Type.findMemberInternal$1(Types.scala:1042)
    at scala.reflect.internal.Types$Type.findMember(Types.scala:1047)
    at scala.reflect.internal.Types$Type.memberBasedOnName(Types.scala:673)
    at scala.reflect.internal.Types$Type.member(Types.scala:637)
    at scala.reflect.internal.Mirrors$RootsBase.staticClass(Mirrors.scala:60)
    at com.github.ghik.silencer.SilencerPlugin$extractSuppressions$.liftedTree1$1(SilencerPlugin.scala:77)
    at com.github.ghik.silencer.SilencerPlugin$extractSuppressions$.silentSym$lzycompute(SilencerPlugin.scala:77)
    at com.github.ghik.silencer.SilencerPlugin$extractSuppressions$.com$github$ghik$silencer$SilencerPlugin$extractSuppressions$$silentSym(SilencerPlugin.scala:76)
    at com.github.ghik.silencer.SilencerPlugin$extractSuppressions$.newPhase(SilencerPlugin.scala:88)
    at com.github.ghik.silencer.SilencerPlugin$extractSuppressions$.newPhase(SilencerPlugin.scala:69)
    at scala.tools.nsc.Global$Run.$anonfun$firstPhase$3(Global.scala:1256)
    at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:169)
    at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:165)
    at scala.tools.nsc.Global$Run.<init>(Global.scala:1256)
    at com.github.ghik.silencer.SilencerPluginTest.compile(SilencerPluginTest.scala:42)
    at com.github.ghik.silencer.SilencerPluginTest.testFile(SilencerPluginTest.scala:53)

Seeing as PluginComponent newPhase is called during Global Run
initialisation, I think it's ok for a `staticClass` lookup to blow up
like this.  Delaying to the phase run should have an equivalent effect.