### PR TITLE
Add Scala 2.13.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala:
+          - 2.13.8
           - 2.13.7
           - 2.13.6
           - 2.13.5
@@ -81,7 +82,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.7]
+        scala: [2.13.8]
         java: [adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -106,6 +107,16 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Download target directories (2.13.8)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-2.13.8-${{ matrix.java }}
+
+      - name: Inflate target directories (2.13.8)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Download target directories (2.13.7)
         uses: actions/download-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ def crossSources = Def.settings(
 inThisBuild(Seq(
   organization := "com.github.ghik",
   scalaVersion := crossScalaVersions.value.head,
-  crossScalaVersions := Seq("2.13.7", "2.13.6", "2.13.5", "2.13.4", "2.13.3", "2.13.2", "2.12.15", "2.12.14", "2.12.13", "2.11.12"),
+  crossScalaVersions := Seq("2.13.8", "2.13.7", "2.13.6", "2.13.5", "2.13.4", "2.13.3", "2.13.2", "2.12.15", "2.12.14", "2.12.13", "2.11.12"),
 
   githubWorkflowTargetTags ++= Seq("v*"),
   githubWorkflowJavaVersions := Seq("adopt@1.11"),


### PR DESCRIPTION
Scala 2.13.8 is on Maven Central already. Also see https://contributors.scala-lang.org/t/scala-2-13-8-release-planning/5487/17
Can you please cut a new release? Thanks!