### PR TITLE
Add 2.12.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - 2.13.4
           - 2.13.3
           - 2.13.2
+          - 2.12.16
           - 2.12.15
           - 2.12.14
           - 2.12.13
@@ -174,6 +175,16 @@ jobs:
           name: target-${{ matrix.os }}-2.13.2-${{ matrix.java }}
 
       - name: Inflate target directories (2.13.2)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.12.16)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-2.12.16-${{ matrix.java }}
+
+      - name: Inflate target directories (2.12.16)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ def crossSources = Def.settings(
 inThisBuild(Seq(
   organization := "com.github.ghik",
   scalaVersion := crossScalaVersions.value.head,
-  crossScalaVersions := Seq("2.13.8", "2.13.7", "2.13.6", "2.13.5", "2.13.4", "2.13.3", "2.13.2", "2.12.15", "2.12.14", "2.12.13", "2.11.12"),
+  crossScalaVersions := Seq("2.13.8", "2.13.7", "2.13.6", "2.13.5", "2.13.4", "2.13.3", "2.13.2", "2.12.16", "2.12.15", "2.12.14", "2.12.13", "2.11.12"),
 
   githubWorkflowTargetTags ++= Seq("v*"),
   githubWorkflowJavaVersions := Seq("adopt@1.11"),


### PR DESCRIPTION
Scala 2.12.16 is released. This PR aims to add it.
https://github.com/scala/scala/releases/tag/v2.12.16