### PR TITLE
Add Scala 2.12.18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - 2.13.4
           - 2.13.3
           - 2.13.2
+          - 2.12.18
           - 2.12.17
           - 2.12.16
           - 2.12.15
@@ -201,6 +202,16 @@ jobs:
         run: |
           tar xf targets.tar
           rm targets.tar
+
+      - name: Download target directories (2.12.18)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-2.12.18-${{ matrix.java }}
+
+      - name: Inflate target directories (2.12.18)
+        run: |
+          tar xf targets.tar
+          rm targets.tar    
 
       - name: Download target directories (2.12.17)
         uses: actions/download-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ inThisBuild(Seq(
   organization := "com.github.ghik",
   scalaVersion := crossScalaVersions.value.head,
   crossScalaVersions := Seq("2.13.10", "2.13.9", "2.13.8", "2.13.7", "2.13.6", "2.13.5", "2.13.4", "2.13.3", "2.13.2",
-    "2.12.17", "2.12.16", "2.12.15", "2.12.14", "2.12.13", "2.11.12"),
+    "2.12.18", "2.12.17", "2.12.16", "2.12.15", "2.12.14", "2.12.13", "2.11.12"),
 
   githubWorkflowTargetTags ++= Seq("v*"),
   githubWorkflowJavaVersions := Seq("adopt@1.11"),


### PR DESCRIPTION
Scala 2.12.18 is released. This PR aims to add it.
https://github.com/scala/scala/releases/tag/v2.12.18

Signed-off-by: yangjie01 [yangjie01@baidu.com](mailto:yangjie01@baidu.com)